### PR TITLE
Notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "bsv": "^2.0.7",
         "chai-spies": "^1.0.0",
         "cleaners": "^0.3.12",
+        "clone-deep": "^4.0.1",
         "commander": "^9.0.0",
         "dotenv": "^16.0.0",
         "joi": "^17.6.0",
@@ -1464,32 +1465,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-<<<<<<< HEAD
-=======
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
->>>>>>> incomplete jobs query.
       }
     },
     "node_modules/buffer": {
@@ -1693,7 +1668,6 @@
         "fsevents": "~2.3.2"
       }
     },
-<<<<<<< HEAD
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -1703,8 +1677,6 @@
         "node": ">=6.0"
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1806,6 +1778,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1989,7 +1974,6 @@
         "typescript": ">=3"
       }
     },
-<<<<<<< HEAD
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -2004,8 +1988,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2312,7 +2294,6 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
-<<<<<<< HEAD
     "node_modules/electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
@@ -2338,8 +2319,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3144,7 +3123,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
@@ -3159,8 +3137,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/hash-base": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
@@ -3539,7 +3515,6 @@
       "integrity": "sha1-RAJZwHloHgNy5SFWqmeiM8OXXe4=",
       "deprecated": "Development of this module has been stopped."
     },
-<<<<<<< HEAD
     "node_modules/is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -3566,8 +3541,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3598,6 +3571,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -3727,11 +3711,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-<<<<<<< HEAD
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3774,8 +3757,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -3844,6 +3825,14 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5405,19 +5394,15 @@
         "randombytes": "^2.1.0"
       }
     },
-<<<<<<< HEAD
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
-=======
->>>>>>> incomplete jobs query.
     "node_modules/sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-<<<<<<< HEAD
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -5430,14 +5415,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-=======
->>>>>>> incomplete jobs query.
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "kind-of": "^6.0.2"
       },
-      "bin": {
-        "sha.js": "bin.js"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -7953,15 +7935,12 @@
         "readdirp": "~3.6.0"
       }
     },
-<<<<<<< HEAD
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "peer": true
     },
-=======
->>>>>>> incomplete jobs query.
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -8047,6 +8026,16 @@
             "ansi-regex": "^5.0.1"
           }
         }
+      }
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
       }
     },
     "color-convert": {
@@ -8198,7 +8187,6 @@
         "ts-node": "^10.7.0"
       }
     },
-<<<<<<< HEAD
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -8215,8 +8203,6 @@
         }
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -8468,7 +8454,6 @@
         }
       }
     },
-<<<<<<< HEAD
     "electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
@@ -8496,8 +8481,6 @@
         }
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9138,7 +9121,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
-<<<<<<< HEAD
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
@@ -9147,8 +9129,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "hash-base": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
@@ -9412,7 +9392,6 @@
       "resolved": "https://registry.npmjs.org/is-hex/-/is-hex-1.1.3.tgz",
       "integrity": "sha1-RAJZwHloHgNy5SFWqmeiM8OXXe4="
     },
-<<<<<<< HEAD
     "is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -9427,8 +9406,6 @@
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
     },
-=======
->>>>>>> incomplete jobs query.
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9448,6 +9425,14 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-promise": {
       "version": "2.2.2",
@@ -9537,11 +9522,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-<<<<<<< HEAD
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -9571,8 +9555,6 @@
         }
       }
     },
-=======
->>>>>>> incomplete jobs query.
     "joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -9631,6 +9613,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -10804,19 +10791,15 @@
         "randombytes": "^2.1.0"
       }
     },
-<<<<<<< HEAD
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
-=======
->>>>>>> incomplete jobs query.
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-<<<<<<< HEAD
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -10826,11 +10809,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-=======
->>>>>>> incomplete jobs query.
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "kind-of": "^6.0.2"
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bsv": "^2.0.7",
     "chai-spies": "^1.0.0",
     "cleaners": "^0.3.12",
+    "clone-deep": "^4.0.1",
     "commander": "^9.0.0",
     "dotenv": "^16.0.0",
     "joi": "^17.6.0",

--- a/src/Stratum/client/get_version.ts
+++ b/src/Stratum/client/get_version.ts
@@ -13,7 +13,7 @@ export type get_version_request = {
 export class GetVersionRequest extends Request {
 
   static valid(message: get_version_request): boolean {
-    return Request.valid(message) && message['method'] === 'client.get_version' && message['params'].length === 0
+    return message['method'] === 'client.get_version' && message['params'].length === 0
   }
 
   static make(id: message_id): get_version_request {

--- a/src/Stratum/mining/authorize.ts
+++ b/src/Stratum/mining/authorize.ts
@@ -16,11 +16,11 @@ export class AuthorizeRequest extends Request {
 
   static read_params(params: parameters): authorization | undefined {
     if ((params.length === 1 && typeof params[0] === 'string') ||
-      (params.length === 2 && typeof params[0] === 'string' && typeof params[1] !== 'string')) return <authorization>params
+      (params.length === 2 && typeof params[0] === 'string' && typeof params[1] === 'string')) return <authorization>params
   }
 
   static valid(message: authorize_request): boolean {
-    return message['method'] === 'mining.authorize'
+    return message['method'] === 'mining.authorize' && this.read_params(message['params'])!=undefined
   }
 
   static username(message: authorize_request): string {

--- a/src/Stratum/mining/authorize.ts
+++ b/src/Stratum/mining/authorize.ts
@@ -2,6 +2,7 @@ import { Request } from '../request'
 import { Response, BooleanResponse, boolean_response } from '../response'
 import { message_id } from '../messageID'
 import { method } from '../method'
+import { parameters } from '../message'
 
 export type authorization = [string, string] | [string]
 
@@ -13,8 +14,13 @@ export type authorize_request = {
 
 export class AuthorizeRequest extends Request {
 
+  static read_params(params: parameters): authorization | undefined {
+    if ((params.length === 1 && typeof params[0] === 'string') ||
+      (params.length === 2 && typeof params[0] === 'string' && typeof params[1] !== 'string')) return <authorization>params
+  }
+
   static valid(message: authorize_request): boolean {
-    return Request.valid(message) && message['method'] === 'mining.authorize'
+    return message['method'] === 'mining.authorize'
   }
 
   static username(message: authorize_request): string {

--- a/src/Stratum/mining/configure.ts
+++ b/src/Stratum/mining/configure.ts
@@ -18,12 +18,12 @@ export type configure_result = {[key: string]: JSONValue;}
 // values of objects containing the parameters for the requests.
 export type extension_requests = {[key: string]: {[key: string] : JSONValue;};}
 
-export type extension_result = [boolean | string, object];
+export type extension_result = [boolean | string, {[key: string]: JSONValue;}];
 
 // an object containing keys for the names of the extensions and
 // values of extension_result. The first value is whether the request
 // was successful and the second contains parameters.
-export type extension_results = {[key: string]: [extension_result, {[key: string]: JSONValue;}];}
+export type extension_results = {[key: string]: extension_result}
 
 export type configure_request = {
   id: message_id,
@@ -235,8 +235,6 @@ export class ExtensionInfo {
 export class ConfigureRequest {
 
   static valid(r: request): boolean {
-    if (!Request.valid(r)) return false
-
     if (r.method !== 'mining.configure') return false
 
     let params = r['params']

--- a/src/Stratum/mining/notify.ts
+++ b/src/Stratum/mining/notify.ts
@@ -18,11 +18,6 @@ export class NotifyParams {
       is_hex(params[2]) && is_hex(params[3]) && Array.isArray(params[4]) &&
       SessionID.valid(params[5]) && SessionID.valid(params[6]) &&
       SessionID.valid(params[7]) && typeof params[8] === 'boolean')) {
-      console.log("invalid notify params x: " + params[1].length + " " +
-        is_hex(params[1]) + (params[1].length == 64) +
-        is_hex(params[2]) + is_hex(params[3]) + Array.isArray(params[4]) +
-        SessionID.valid(params[5]) + SessionID.valid(params[6]) +
-        SessionID.valid(params[7]) + (typeof params[8] === 'boolean'))
       return false
     }
 
@@ -140,11 +135,25 @@ export type notify = {
 
 export class Notify extends Notification {
 
-  static valid(message: JSONValue): boolean {
+  static valid(message: notify): boolean {
     let n = Notification.read(message)
     if (!n || n['method'] !== "mining.notify") return false
 
     return NotifyParams.valid(n['params'])
+  }
+
+  static read(message: JSONValue): notify | undefined {
+    let n = Notification.read(message)
+    if (!n || n['method'] !== "mining.notify" || n.params.length != 9 ||
+      typeof n.params[0] !== 'string' || typeof n.params[1] !== 'string' ||
+      typeof n.params[2] !== 'string' || typeof n.params[3] !== 'string' ||
+      !Array.isArray(n.params[4]) || typeof n.params[5] !== 'string' ||
+      typeof n.params[6] !== 'string' || typeof n.params[7] !== 'string' ||
+      typeof n.params[8] !== 'boolean') return
+
+    for (let x of n.params[4]) if (typeof x !== 'string') return
+    
+    if (NotifyParams.valid(n['params'])) return <notify>n
   }
 
   static make(

--- a/src/Stratum/mining/set_difficulty.ts
+++ b/src/Stratum/mining/set_difficulty.ts
@@ -11,17 +11,19 @@ export type set_difficulty = {
 
 export class SetDifficulty extends Notification {
 
-  static valid(message: JSONValue): boolean {
-    let n = Notification.read(message)
-    if (!n || n['method'] !== "mining.set_difficulty") {
-      return false
-    }
-
-    let params = message['params']
-    return params.length === 1 && typeof params[0] === 'number' && params[0] > 0
+  static valid(message: set_difficulty): boolean {
+    return message['method'] === "mining.set_difficulty" && message['params'][0] > 0
   }
 
-  static difficulty(message): boostpow.Difficulty {
+  static read(message: JSONValue): set_difficulty | undefined {
+    let n = Notification.read(message)
+    if (!n) return
+
+    let params = message['params']
+    if (params.length === 1 && typeof params[0] === 'number' && SetDifficulty.valid(<set_difficulty>n)) return <set_difficulty>n
+  }
+
+  static difficulty(message: set_difficulty): boostpow.Difficulty {
     if (SetDifficulty.valid(message)) return new boostpow.Difficulty(message['params'][0])
 
     throw "invalid set_difficulty"

--- a/src/Stratum/mining/submit.ts
+++ b/src/Stratum/mining/submit.ts
@@ -3,6 +3,7 @@ import { Response, BooleanResponse, boolean_response } from '../response'
 import { message_id } from '../messageID'
 import { SessionID } from '../sessionID'
 import { method } from '../method'
+import { parameters } from '../message'
 import { error } from '../error'
 import * as boostpow from 'boostpow'
 
@@ -16,6 +17,12 @@ export class Share {
       /^(([0-9a-f][0-9a-f])*)|(([0-9A-F][0-9A-F])*)$/.test(params[4]) &&
       (params.length === 5 ||
         (params.length === 6 && SessionID.valid(params[5])))
+  }
+
+  static read(params: parameters): share | undefined {
+    if (params.length < 5 || params.length > 6) return
+    for(let elem of params) if (typeof elem !== 'string') return
+    if (Share.valid(<share>params)) return <share>params
   }
 
   static workerName(x: share): string {
@@ -94,7 +101,7 @@ export type submit_request = {
 export class SubmitRequest extends Request {
 
   static valid(message: submit_request): boolean {
-    if (!(Request.valid(message) && message['method'] === "mining.submit")) {
+    if (!(message['method'] === "mining.submit")) {
       return false
     }
 

--- a/src/Stratum/mining/subscribe.ts
+++ b/src/Stratum/mining/subscribe.ts
@@ -17,7 +17,7 @@ export type subscribe_request = {
 export class SubscribeRequest extends Request {
 
   static valid(message: subscribe_request): boolean {
-    if (!(Request.valid(message) && message['method'] === 'mining.subscribe')) {
+    if (!(message['method'] === 'mining.subscribe')) {
       return false
     }
 

--- a/src/Stratum/request.ts
+++ b/src/Stratum/request.ts
@@ -19,33 +19,23 @@ export class Request {
     params: Joi.array().required()
   })
 
-  static valid(message: request): boolean {
-    if (Request.schema.validate(message).error) return false
-
-    for (let x of message.params) if (x === undefined) return false
-
-    return true
-  }
-
   static read(message: JSONValue): request | undefined {
-    if (Request.valid(<request>message)) return <request>message
+    if (Request.schema.validate(message).error) return
+
+    for (let x of (<request>message).params) if (x === undefined) return
+
+    return <request>message
   }
 
   static id(message: request): message_id {
-    if (Request.valid(message)) return message['id']
-
-    throw "invalid request"
+    return message['id']
   }
 
   static method(message: request): method {
-    if (Request.valid(message)) return message['method']
-
-    throw "invalid request"
+    return message['method']
   }
 
   static params(message: request): parameters {
-    if (Request.valid(message)) return message['params']
-
-    throw "invalid request"
+    return message['params']
   }
 }

--- a/src/Stratum/response.ts
+++ b/src/Stratum/response.ts
@@ -2,6 +2,7 @@ import { message_id, MessageID } from './messageID'
 import { method } from './method'
 import { error, Error } from './error'
 import { result } from './message'
+import { JSONValue } from '../json'
 
 // A response is a reply to a request.
 export interface response {
@@ -11,9 +12,15 @@ export interface response {
 }
 
 export class Response {
+
   static valid(message: response): boolean {
-    return typeof message === 'object' && MessageID.valid(message['id']) &&
-      message['result'] !== undefined && Error.valid(message['err'])
+    return message['result'] !== undefined && Error.valid(message['err'])
+  }
+
+  static read(message: JSONValue): response | undefined {
+    if (typeof message == 'object' && MessageID.valid(message['id']) &&
+      Error.valid(message['err']) &&
+      Response.valid(<response><unknown>message)) return <response><unknown>message
   }
 
   static id(message: response): message_id {
@@ -52,7 +59,7 @@ export class Response {
     return Response.error(message) !== null
   }
 
-  static make(id: message_id, result: result  , err?: error): response {
+  static make(id: message_id, result: result, err?: error): response {
     if (err === undefined) {
       return {id: id, result: result, err: null}
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { Event, Events } from './event'
 import * as net from 'net'
 import { asOptional, asNumber } from 'cleaners'
 import { Session } from './session'
-import { handleStratumMessage, handleStratumRequest } from './stratum'
+import { stratum } from './stratum'
 import { server_session } from './server_session'
 import { log } from './log'
 import { listJobs } from './powco'
@@ -30,7 +30,7 @@ export class Server {
 
       // this session is not immediately deleted because it adds itself
       // to a global object called sessions containing all sessions.
-      new Session({ socket }, handleStratumMessage(handleStratumRequest(server_session(this.jobs.subscribe, true))))
+      new Session({ socket }, stratum(server_session(this.jobs.subscribe, true)))
 
     })
 

--- a/src/server_session.ts
+++ b/src/server_session.ts
@@ -1,181 +1,282 @@
 import { error, Error } from './Stratum/error'
 import { JSONValue } from './json'
-import { SessionID } from './Stratum/sessionID'
+import { SessionID, session_id } from './Stratum/sessionID'
 import { request } from './Stratum/request'
 import { response } from './Stratum/response'
+import { result, parameters } from './Stratum/message'
 import { notification } from './Stratum/notification'
-import { extranonce } from './Stratum/mining/set_extranonce'
+import { extranonce, SetExtranonce } from './Stratum/mining/set_extranonce'
+import { set_difficulty, SetDifficulty } from './Stratum/mining/set_difficulty'
+import { notify, Notify } from './Stratum/mining/notify'
 import { subscriptions, subscribe_request, subscribe_response, SubscribeRequest, SubscribeResponse }
   from './Stratum/mining/subscribe'
 import { configure_request, configure_response, extension_requests,
+  extension_result, extension_results,
   ConfigureRequest, ConfigureResponse, Extensions }
   from './Stratum/mining/configure'
 import { authorize_request, AuthorizeRequest, AuthorizeResponse }
   from './Stratum/mining/authorize'
-import { submit_request, SubmitRequest, SubmitResponse }
+import { Share, submit_request, SubmitRequest, SubmitResponse }
   from './Stratum/mining/submit'
 import { notify_params, NotifyParams } from './Stratum/mining/notify'
 import { StratumJob, Worker } from './jobs'
+import { Local, Remote } from './stratum'
 import { StratumRequest, StratumResponse, StratumHandler, StratumHandlers } from './Stratum/handlers/base'
 import * as boostpow from 'boostpow'
 
 // Subscribe lets us subscribe to new jobs. The backend could be boost or a mining pool.
 type Subscribe = (w: Worker) => StratumJob | undefined
 
+// Parameters we keep in memory for a given extension.
+type ExtensionParameters = {[key: string]: JSONValue;}
+
+// We take the parameters that are requested for a given extension and
+// return the parameters we want to remember and those we want to send back
+// to the client.
+type HandleExtension = (requested: ExtensionParameters) =>
+  {'reply': extension_result, 'keep'?: ExtensionParameters}
+
 export function server_session(
   select: Subscribe,
   can_submit_without_authorization: boolean,
   // undefined indicates that Stratum extensions are not supported.
   // Otherwise there is a list of supported extensions.
-  extensions_supported?: {[key: string]: {[key: string]: JSONValue;}}
-): StratumHandlers {
+  extension_handlers?: {[key: string]: HandleExtension}
+): Local {
+  return (remote: Remote, disconnect: () => void) => {
+    let running: boolean = true
 
-  // undefined indicates that this session does not support Stratum
-  // extensions because the configure message was never sent. Otherwise,
-  // there is a list of supported extensions.
-  let extensions: undefined | {[key: string]: {[key: string]: JSONValue;}}
+    function close() {
+      running = false
+      disconnect()
+    }
 
-  // before the first message is sent, we don't know if we are using the
-  // extended version of the protocol.
-  let extended_protocol: undefined | boolean
+    // undefined indicates that this session does not support Stratum
+    // extensions because the configure message was never sent. Otherwise,
+    // there is a list of supported extensions.
+    let extensions: undefined | {[key: string]: ExtensionParameters}
 
-  function extension_parameters(name: string): {[key: string]: JSONValue;} {
-    if (!extended_protocol) return {}
+    // before the first message is sent, we don't know if we are using the
+    // extended version of the protocol.
+    let extended_protocol: undefined | boolean
 
-    let p = extensions[name]
-    if (!p) return {}
+    // which parameters do we store for a given extension?
+    function extension_parameters(name: string): ExtensionParameters {
+      if (!extended_protocol) return {}
 
-    return p
-  }
+      let p = extensions[name]
+      if (!p) return {}
 
-  function extension_supported(name: string): boolean {
-    if (!extended_protocol) return false
+      return p
+    }
 
-    let p = extensions[name]
-    if (!p) return false
+    // is a given extension supported?
+    function extension_supported(name: string): boolean {
+      if (!extended_protocol) return false
 
-    return true
-  }
+      let p = extensions[name]
+      if (!p) return false
 
-  function minimum_difficulty(): number {
-    let p = extension_parameters('minimum_difficulty')['value']
-    if (p === undefined) return 0
-    return <number>p
-  }
+      return true
+    }
 
-  let jobs: StratumJob[] = []
+    // minimum difficulty is an extension that let us remember a minimum
+    // difficulty to send to the client. If the extension is not supported,
+    // this function returns zero.
+    function minimum_difficulty(): number {
+      let p = extension_parameters('minimum_difficulty')['value']
+      if (p === undefined) return 0
+      return <number>p
+    }
 
-  let user_agent: undefined | string
+    // list of recent jobs.
+    let jobs: StratumJob[] = []
 
-  let extranonce: undefined | extranonce
+    // set during the subscribe method.
+    let id: session_id | undefined
 
-  // If the subscribe method has not yet been sent, this is undefined.
-  // Otherwise, it has the subscriptions that were sent.
-  let subscriptions: undefined | subscriptions
+    function new_job(j: StratumJob) {
+      if (extension_supported("subscribe_extranonce"))
+        remote.notify({id:null, method:'mining.set_extranonce', params: [id, j.extranonce2Size]})
+      remote.notify(SetDifficulty.make(NotifyParams.nbits(j.notify)))
+      remote.notify({id: null, method:'mining.notify', params: j.notify})
+    }
 
-  function subscribed(): boolean {
-    return subscriptions !== undefined
-  }
+    // the user agent string sent in the subscribe method.
+    let user_agent: undefined | string
 
-  // undefined indicates that the authorize request has not been sent.
-  let username: undefined | string
+    // If the subscribe method has not yet been sent, this is undefined.
+    // Otherwise, it has the subscriptions that were sent.
+    let subscriptions: undefined | subscriptions
 
-  function authorized(): boolean {
-    return username !== undefined
-  }
+    function subscribed(): boolean {
+      return subscriptions !== undefined
+    }
 
-  function handleConfigure(request: StratumRequest): StratumResponse {
-    // If extensions are not supported, then we don't know about this message.
-    if (!extensions_supported || extended_protocol === false)
+    // undefined indicates that the authorize request has not been sent.
+    let username: undefined | string
+
+    function authorized(): boolean {
+      return username !== undefined
+    }
+
+    // configure is an optional first message that determines wheher
+    // extensions and supported and which ones.
+    function handleConfigure(request: request): void {
+      remote.respond(((requested: extension_requests, result, error) => {
+        // If extensions are not supported, then we don't know about this message.
+        if (!extension_handlers || extended_protocol === false)
+          return error(Error.ILLEGAL_METHOD)
+
+        if (!requested) return error(Error.ILLEGAL_PARARMS)
+
+        // If we have already received the configure method, then only minimum_difficulty is allowed.
+        if (extended_protocol === true && extension_supported('minimum_difficulty')) {
+          let min_diff = requested['minimum_difficulty']
+          if (!min_diff || Object.keys(requested).length != 1)
+            return error(Error.ILLEGAL_PARARMS)
+
+          let it = extension_handlers['minimum_difficulty'](requested['minimum_difficulty'])
+
+          let keep = it['keep']
+          if (keep) extensions['minimum_difficulty'] = keep
+
+          return result({'minimum_difficulty': it['reply']})
+        } return error(Error.ILLEGAL_METHOD)
+
+        extended_protocol = true
+        extensions = {}
+        let reply: extension_results = {}
+
+        for (let key of Object.keys(requested)) {
+          let h = extension_handlers[key]
+
+          if (!h) {
+            reply[key] = [false, {}]
+            continue
+          }
+
+          let it = h(requested[key])
+          reply[key] = it['reply']
+
+          let keep = it['keep']
+          if (keep) extensions[key] = keep
+        }
+
+        return result(reply)
+      })(Extensions.extension_requests(request.params),
+        (r: extension_results) => {
+          return {id: request.id, result: Extensions.configure_response_result(r), err: null}
+        },
+        (err: number) => {
+          return {id: request.id, result: null, err: Error.make(err)}
+        }
+      ))
+    }
+
+    function handleSubscribe(request: request): void {
+      ((sub, error) => {
+        if (!sub) return error(Error.ILLEGAL_PARARMS)
+
+        if (extended_protocol === undefined) extended_protocol = false
+
+        // subscribe can only be called once. -- or can it?
+        if (subscribed()) return error(Error.ILLEGAL_METHOD)
+
+        user_agent = SubscribeRequest.userAgent(sub)
+
+        // if we use subscribe_extranonce, then the result is different.
+        let subscribe_extranonce: boolean = extension_supported("subscribe_extranonce")
+
+        let job = select({
+          'subscribe_extranonce': subscribe_extranonce,
+          'new_job': new_job,
+          'hashpower':() => { return {'hashpower': 0, 'certainty': 0} },
+          'minimum_difficulty': minimum_difficulty,
+          'cancel': close
+        })
+        if (!job) return error(Error.INTERNAL_ERROR)
+
+        jobs.push(job)
+
+        subscriptions = subscribe_extranonce ?
+          [['mining.notify', SubscribeResponse.random_subscription_id()],
+            ['mining.set_difficulty', SubscribeResponse.random_subscription_id()],
+            ['mining.set_extranonce', SubscribeResponse.random_subscription_id()]] :
+          [['mining.notify', SubscribeResponse.random_subscription_id()],
+            ['mining.set_difficulty', SubscribeResponse.random_subscription_id()]]
+
+        // has the user requestd an extranonce1?
+        let n1 = SubscribeRequest.extranonce1(sub)
+        let id = n1 ? n1.hex : SessionID.random()
+
+        remote.respond({id: request.id, result: [subscriptions, id, job.extranonce2Size], err: null})
+        remote.notify(SetDifficulty.make(NotifyParams.nbits(job.notify)))
+        remote.notify({id:null, params: job.notify, method: 'mining.notify'})
+      })(SubscribeRequest.read(request),
+      (err: number) => {
+        remote.respond({id: request.id, result: null, err: Error.make(err)})
+        close()
+      })
+    }
+
+    function authorize(params: parameters): StratumResponse {
+      let auth = AuthorizeRequest.read_params(params)
+
+      if (!auth) return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
+
+      if (extended_protocol === undefined) extended_protocol = false
+
+      // can only auhorize once.
+      if (authorized()) return {result: null, err: Error.make(Error.ILLEGAL_METHOD)}
+
+      // for now we accept all authorization requests.
+      username = auth[0]
+      return {result: true, err: null}
+    }
+
+    function handleAuthorize(request: request): void {
+      let response: StratumResponse = authorize(request.params)
+      response.id = request.id
+      remote.respond(<response>response)
+      if (response.err != null) close()
+    }
+
+    function submit(request: parameters): StratumResponse {
+      let x = Share.read(request)
+      if (!x) return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
+      // TODO
       return {result: null, err: Error.make(Error.ILLEGAL_METHOD)}
-
-    let requested: extension_requests = Extensions.extension_requests(request.params)
-    if (!requested) return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
-
-    // If we have already received the configure method, then only minimum_difficulty is allowed.
-    if (extended_protocol === true) {
-      let min_diff = requested['minimum_difficulty']
-      if (!min_diff || Object.keys(extended_protocol).length != 1)
-        return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
     }
 
-    extended_protocol = true
-
-    // TODO finish this.
-    return {result: null, err: Error.make(Error.INTERNAL_ERROR)}
-  }
-
-  function handleSubscribe(request: StratumRequest): StratumResponse {
-    let sub = SubscribeRequest.read(request)
-    if (!sub) return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
-
-    if (extended_protocol === undefined) extended_protocol = false
-
-    // subscribe can only be called once.
-    if (subscribed()) return {result: null, err: Error.make(Error.ILLEGAL_METHOD)}
-
-    user_agent = SubscribeRequest.userAgent(sub)
-
-    let subscribe_extranonce: boolean = extension_supported("subscribe_extranonce")
-
-    let job = select({
-      'subscribe_extranonce': subscribe_extranonce,
-      'new_job': (Job) => {},
-      'hashpower':() => { return {'hashpower': 0, 'certainty': 0} },
-      'minimum_difficulty': minimum_difficulty,
-      'cancel': () => {}
-    })
-    if (!job) return {result:null, err: Error.make(Error.INTERNAL_ERROR)}
-
-    jobs.push(job)
-
-    if (subscribe_extranonce) {
-      subscriptions = [['mining.notify', SubscribeResponse.random_subscription_id()],
-        ['mining.set_difficulty', SubscribeResponse.random_subscription_id()],
-        ['mining.set_extranonce', SubscribeResponse.random_subscription_id()]]
-    } else {
-      subscriptions = [['mining.notify', SubscribeResponse.random_subscription_id()],
-        ['mining.set_difficulty', SubscribeResponse.random_subscription_id()]]
+    function handleSubmit(request: request): void {
+      let response: StratumResponse = submit(request.params)
+      response.id = request.id
+      remote.respond(<response>response)
     }
 
-    // has the user requestd an extranonce1?
-    let n1 = SubscribeRequest.extranonce1(sub)
-    let extranonce = [n1 ? n1.hex : SessionID.random(), job.extranonce2Size]
-
-    return {result:[subscriptions, extranonce[0], extranonce[1]], err: null}
-  }
-
-  function handleAuthorize(request: StratumRequest): StratumResponse {
-    let auth = AuthorizeRequest.read(request)
-    if (!auth) return {result: null, err: Error.make(Error.ILLEGAL_PARARMS)}
-
-    if (extended_protocol === undefined) extended_protocol = false
-
-    // can only auhorize once.
-    if (authorized()) return {result: null, err: Error.make(Error.ILLEGAL_METHOD)}
-
-    // for now we accept all authorization requests.
-    username = AuthorizeRequest.username(auth)
-    return {result: true, err: null}
-  }
-
-  return {
-    'mining.configure': (request: StratumRequest) => {
-      return new Promise<StratumResponse>((resolve, reject) => {
-        return resolve(handleConfigure(request))
-      })
-    },
-
-    'mining.subscribe': (request: StratumRequest) => {
-      return new Promise<StratumResponse>((resolve, reject) => {
-        return resolve(handleSubscribe(request))
-      })
-    },
-
-    'mining.authorize': (request: StratumRequest) => {
-      return new Promise<StratumResponse>((resolve, reject) => {
-        return resolve(handleAuthorize(request))
-      })
+    let handleRequest = {
+      'mining.configure': handleConfigure,
+      'mining.subscribe': handleSubscribe,
+      'mining.authorize': handleAuthorize,
+      'mining.submit': handleSubmit
     }
+
+    let handle = {
+      'notify': (n: notification) => {
+        // nothing to do here because there is no notification that
+        // we need to respond to as the server.
+      },
+      'request': (r: request) => {
+        let handle = handleRequest[r.method]
+        if (!handle) {
+          remote.respond({id: r.id, result: null, err: Error.make(Error.ILLEGAL_METHOD)})
+          return
+        }
+        handle(r)
+      }
+    }
+
+    return handle
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,7 @@ import { log } from './log'
 import * as net from 'net'
 
 import * as uuid from 'uuid'
+import { JSONValue } from './json'
 
 interface HostPort {
   ip: string;
@@ -24,6 +25,15 @@ interface NewSession {
   socket: net.Socket
 }
 
+export type Connection = {
+  send: (j: JSONValue) => void,
+  close: () => void
+}
+
+export type Receive = (msg: JSONValue) => void
+
+export type Protocol = (conn: Connection) => Receive
+
 export class Session {
 
   sessionId: SessionId
@@ -34,9 +44,9 @@ export class Session {
 
   open: boolean
 
-  handleMessage: (data: Buffer, socket: net.Socket) => void
+  handleMessage: Receive
 
-  constructor({ socket }: NewSession, messageHandler: (data: Buffer, socket: net.Socket) => void) {
+  constructor({ socket }: NewSession, remote: Protocol) {
 
     this.connectedAt = new Date()
 
@@ -46,7 +56,7 @@ export class Session {
 
     this.open = true
 
-    this.handleMessage = messageHandler
+    this.handleMessage = remote({send: this.sendJSON, close: this.disconnect})
 
     log.info('socket.connect', {
 
@@ -74,13 +84,18 @@ export class Session {
 
     this.socket.on('data', data => {
 
-      this.handleMessage(data, this.socket)
+      this.handleMessage(JSON.parse(data.toString()))
 
     })
 
     sessions[this.sessionId] = this
 
   }
+
+  sendJSON(x: JSONValue): void {
+    this.socket.write(`${JSON.stringify(x)}\n`)
+  }
+
   disconnect() {
 
     this.socket.end();

--- a/src/session.ts
+++ b/src/session.ts
@@ -56,7 +56,7 @@ export class Session {
 
     this.open = true
 
-    this.handleMessage = remote({send: this.sendJSON, close: this.disconnect})
+    this.handleMessage = remote({send: this.sendJSON.bind(this), close: this.disconnect.bind(this)})
 
     log.info('socket.connect', {
 
@@ -83,7 +83,6 @@ export class Session {
     })
 
     this.socket.on('data', data => {
-
       this.handleMessage(JSON.parse(data.toString()))
 
     })

--- a/src/session.ts
+++ b/src/session.ts
@@ -46,6 +46,8 @@ export class Session {
 
   handleMessage: Receive
 
+  incompleteMsgs: string
+
   constructor({ socket }: NewSession, remote: Protocol) {
 
     this.connectedAt = new Date()
@@ -55,6 +57,8 @@ export class Session {
     this.socket = socket
 
     this.open = true
+
+    this.incompleteMsgs=""
 
     this.handleMessage = remote({send: this.sendJSON.bind(this), close: this.disconnect.bind(this)})
 
@@ -83,8 +87,13 @@ export class Session {
     })
 
     this.socket.on('data', data => {
-      this.handleMessage(JSON.parse(data.toString()))
-
+      this.incompleteMsgs+=data.toString();
+      while(this.incompleteMsgs.includes('\n')) {
+        const curPoint=this.incompleteMsgs.indexOf('\n');
+        const msg=this.incompleteMsgs.substring(0,curPoint)
+        this.incompleteMsgs=this.incompleteMsgs.substring(curPoint+1)
+        this.handleMessage(JSON.parse(msg))
+      }
     })
 
     sessions[this.sessionId] = this

--- a/src/stratum.ts
+++ b/src/stratum.ts
@@ -9,65 +9,100 @@ import * as Joi from 'joi'
 // Stratum protocol documentation:
 // https://docs.google.com/document/d/1ocEC8OdFYrvglyXbag1yi8WoskaZoYuR5HGhwf0hWAY/edit
 
+import { session_id } from './Stratum/sessionID'
+import { method } from './Stratum/method'
+import { parameters, result } from './Stratum/message'
 import { error, Error } from './Stratum/error'
 import { request, Request } from './Stratum/request'
 import { response, Response } from './Stratum/response'
+import { notification, Notification } from './Stratum/notification'
 
 import { StratumRequest, StratumResponse, StratumHandler, StratumHandlers } from './Stratum/handlers/base'
 
-export function handleStratumRequest(handlers: StratumHandlers): (request: request) => Promise<response> {
-  return async (request: request) => {
+import { JSONValue } from './json'
+import { Connection, Receive, Protocol } from './session'
 
-    var response: StratumResponse
+// Remote represents a connection to a remote Stratum implementation. Could
+// be server or client.
+export interface Remote {
+  'request': (m: method, p: parameters, callback: (r: result) => void) => void,
+  'notify': (n: notification) => void,
+  'respond': (r: response) => void,
+}
 
-    try {
+// remote_peer takes a way to send json messages and turns that into a Remote
+// as well as a function for receiving response messages from this remote client
+// that reply to request messages that have been sent to it.
+function remote_peer(conn: Connection):
+  {remote: Remote, receive: (r: response) => void} {
+  let counter = 0
 
-      let handler: StratumHandler = handlers[request.method]
+  let ids: {[key: session_id]: (r: result) => void} = {}
 
-      if (handler) {
-
-        log.info(`stratum.request.${request.method}`, request.params)
-
-        response = await handler(request)
-
-        log.info(`stratum.response.${request.method}`, response)
-
-      } else {
-
-        response = {
-          err: Error.make(Error.ILLEGAL_METHOD),
-          result: null
-        }
-
-      }
-
-    } catch(error) {
-
-      response = { err: Error.make(Error.UNKNOWN), result: null }
-
-      log.error('stratum.message.error: name = ' + error.name + "; message = " + error.msg)
-      log.info('stratum.message.error: name = ' + error.name + "; message = " + error.msg)
-
+  return {
+    'remote' : {
+      'request': (m: method, p: parameters, callback: (r: result) => void) => {
+        ids[counter] = callback
+        conn.send({id: counter, method: m, params: p})
+        counter++
+      },
+      'notify': (n: notification) => {
+        conn.send(n)
+      },
+      'respond': (r: response) => {
+        conn.send(<JSONValue><unknown>r)
+      },
+    },
+    'receive': (r: response) => {
+      let back = ids[r.id]
+      if (!back) conn.close()
+      back(r.result)
     }
-
-    response['id'] = request.id
-    return <response>response
   }
 }
 
-export function handleStratumMessage(handleRequest: (request: request) => Promise<response>): (data: Buffer, socket: net.Socket) => void {
-  return async (data: Buffer, socket: net.Socket) => {
-    log.info('socket.message.data', {data: data.toString() })
+// Local represents a local stratum implementation which could also be a
+// client or server, depending on the implementation. It takes a Remote and
+// provides functions for handling notifications and requests from the
+// remote client.
+export type Local = (r: Remote, close: () => void) => {
+  'notify': (notification) => void,
+  'request': (request) => void,
+}
 
-    var request: request = <request>JSON.parse(data.toString())
-    if (!Request.valid(request)) {
-      log.info('invalid message.')
-      socket.end()
+// stratum takes a Local implementation and provides a Protocl, which means
+// that it takes a Connection and finally completes the circuite between client
+// and server.
+export function stratum(local: Local): Protocol {
+  return (conn: Connection) => {
+    let remote = remote_peer(conn)
+    let self = local(remote.remote, conn.close)
+    return async (msg: JSONValue) => {
+      try {
+        let request = Request.read(msg)
+        if (request) {
+          self.request(request)
+          return
+        }
+
+        let notification = Notification.read(msg)
+        if (notification) {
+          self.notify(notification)
+          return
+        }
+
+        let response = Response.read(msg)
+        if (response) {
+          remote.receive(response)
+          return
+        }
+
+        log.info('invalid message.')
+        conn.close()
+      } catch (error) {
+        log.error('stratum.message.error: name = ' + error.name + "; message = " + error.msg)
+        log.info('stratum.message.error: name = ' + error.name + "; message = " + error.msg)
+      }
     }
-
-    var response: response = await handleRequest(request)
-    log.info('socket.message.response', {data: response.toString() })
-
-    socket.write(`${JSON.stringify(response)}\n`)
   }
 }

--- a/test/stratum_handlers_test.ts
+++ b/test/stratum_handlers_test.ts
@@ -8,6 +8,8 @@ import { StratumResponse } from '../src/Stratum/handlers/base'
 import { SubscribeResponse } from '../src/Stratum/mining/subscribe'
 import { ConfigureResponse, Extensions } from '../src/Stratum/mining/configure'
 import { AuthorizeResponse } from '../src/Stratum/mining/authorize'
+import { SetDifficulty } from '../src/Stratum/mining/set_difficulty'
+import { Notify } from '../src/Stratum/mining/notify'
 import { stratum } from '../src/stratum'
 import { BoostOutput, job_manager } from '../src/jobs'
 import { private_key_wallet } from '../src/bitcoin'
@@ -135,6 +137,19 @@ describe("Stratum Handlers Client -> Server -> Client", () => {
     expect(response).to.not.equal(undefined)
     expect(SubscribeResponse.valid(response)).to.equal(true)
     expect(Response.error(response)).to.equal(null)
+
+    // we should get two more messages at this point, one for set_difficulty and
+    // another for notify.
+
+    let notification1 = dummy.end.read()
+    expect(notification1).to.not.equal(undefined)
+
+    let notification2 = dummy.end.read()
+    expect(notification2).to.not.equal(undefined)
+
+    expect(
+      (!!SetDifficulty.read(notification1) && !!Notify.read(notification2)) ||
+      (!!SetDifficulty.read(notification2) && !!Notify.read(notification1))).to.equal(true)
   })
 
   it("mining.configure should return the correct response for extensions not supported", async () => {

--- a/test/stratum_message_test.ts
+++ b/test/stratum_message_test.ts
@@ -120,8 +120,6 @@ describe("Stratum Messages", () => {
   it("should distinguish valid and invalid set_difficulty messages", async () => {
     expect(SetDifficulty.valid({id:null, method: 'mining.set_difficulty', params: [1]})).to.be.equal(true)
     expect(SetDifficulty.valid({id:null, method: 'mining.set_difficulty', params: [1.1]})).to.be.equal(true)
-    expect(SetDifficulty.valid({id:null, method: 'mining.set_difficulty', params: []})).to.be.equal(false)
-    expect(SetDifficulty.valid({id:null, method: 'mining.set_difficulty', params: [""]})).to.be.equal(false)
     expect(SetDifficulty.valid({id:null, method: '', params: [1]})).to.be.equal(false)
   })
 


### PR DESCRIPTION
We update the boost-stratum server to be able to send notifications. This involves a change in the architecture of the system. The previous version was based on a request-response model, which doesn't really make sense for stratum despite the use of certain messages which are called 'request' and 'response'. Some responses to requests require more than just a response. For example, a disconnection or some notifications after the response. In other words, the server needs to be able to respond to requests in a more general way rather than with a single response message. We have accomplished this by giving the message handlers access to the connection itself, with the ability to send as much as they want and disconnect. The handlers no longer return a response. 